### PR TITLE
Add Solana arbitrage app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # determo13
+
+This project provides a basic skeleton for an arbitrage trading app on Solana.
+It demonstrates the overall structure, including a CLI and configuration, but
+does not implement real trading logic.
+
+## Usage
+
+Run the CLI in test mode:
+
+```bash
+python app.py --mode test
+```
+
+The command-line interface and module stubs can be extended to integrate the
+Jupiter aggregator API, Helius data sources, and real trade execution.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,29 @@
+"""Command line interface for the arbitrage trading app."""
+
+import click
+
+from arbitrage.config import AppConfig
+from arbitrage.scanner import scan_arbitrage
+from arbitrage.executor import execute_trade
+
+
+@click.command()
+@click.option("--mode", type=click.Choice(["test", "live"]), default="test", help="Run mode")
+@click.option("--dashboard", is_flag=True, help="Launch dashboard")
+def main(mode: str, dashboard: bool) -> None:
+    """Entry point for the CLI."""
+    config = AppConfig(mode=mode)
+    click.echo(f"Running in {config.mode} mode")
+
+    if dashboard:
+        click.echo("Dashboard not implemented")
+
+    try:
+        for opportunity in scan_arbitrage(config):
+            execute_trade(config, opportunity)
+    except NotImplementedError as exc:
+        click.echo(f"Feature not implemented: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/arbitrage/config.py
+++ b/arbitrage/config.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class AppConfig:
+    """Configuration for the trading app."""
+    mode: str = "test"  # "test" or "live"
+    min_profit_usd: float = 0.5
+    max_slippage_pct: float = 0.3
+    trade_cooldown_sec: int = 15
+    watchlist_tokens: List[str] = field(default_factory=lambda: ["SOL", "USDC", "USDT"])
+
+    @property
+    def is_live(self) -> bool:
+        return self.mode == "live"

--- a/arbitrage/executor.py
+++ b/arbitrage/executor.py
@@ -1,0 +1,21 @@
+"""Trade execution stubs."""
+
+from .config import AppConfig
+
+
+def execute_trade(config: AppConfig, opportunity: dict) -> str:
+    """Execute a trade based on the provided opportunity.
+
+    Parameters
+    ----------
+    config:
+        Application configuration.
+    opportunity:
+        Arbitrage opportunity details.
+
+    Returns
+    -------
+    str
+        Transaction signature.
+    """
+    raise NotImplementedError("Trade execution not implemented")

--- a/arbitrage/scanner.py
+++ b/arbitrage/scanner.py
@@ -1,0 +1,12 @@
+"""Arbitrage opportunity scanner stubs."""
+
+from .config import AppConfig
+
+
+def scan_arbitrage(config: AppConfig):
+    """Yield arbitrage opportunities.
+
+    This is a placeholder implementation. A real version would query
+    Jupiter's API and evaluate token routes for profit potential.
+    """
+    raise NotImplementedError("Arbitrage scanning not implemented")

--- a/arbitrage/wallet.py
+++ b/arbitrage/wallet.py
@@ -1,0 +1,13 @@
+"""Wallet integration stubs."""
+
+class Wallet:
+    def __init__(self, keypair_path: str | None = None) -> None:
+        self.keypair_path = keypair_path
+        # TODO: load keypair and connect to Solana
+
+    def get_balance(self) -> float:
+        """Return wallet balance in SOL.
+
+        This is a stub that would normally query the Solana RPC.
+        """
+        raise NotImplementedError("Wallet balance fetch not implemented")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+import sys
+import pathlib
+import subprocess
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+def test_cli_help():
+    result = subprocess.run([sys.executable, "app.py", "--help"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "--mode" in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,8 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from arbitrage.config import AppConfig
+
+def test_default_config():
+    cfg = AppConfig()
+    assert cfg.mode == "test"
+    assert cfg.is_live is False
+    assert "SOL" in cfg.watchlist_tokens


### PR DESCRIPTION
## Summary
- create minimal CLI and module stubs
- add configuration dataclass
- include basic README usage instructions
- implement simple tests

## Testing
- `pytest -q`