### PR TITLE
Fill stub modules with simple example logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This project provides a basic skeleton for an arbitrage trading app on Solana.
 It demonstrates the overall structure, including a CLI and configuration, but
-does not implement real trading logic.
+the trading logic is intentionally simplistic.  The scanner, executor and
+wallet modules ship with minimal implementations so the application can run
+without raising ``NotImplementedError`` while still leaving plenty of room for
+real integration work.
 
 ## Usage
 

--- a/arbitrage/executor.py
+++ b/arbitrage/executor.py
@@ -6,6 +6,12 @@ from .config import AppConfig
 def execute_trade(config: AppConfig, opportunity: dict) -> str:
     """Execute a trade based on the provided opportunity.
 
+    This function does not perform any real blockchain interaction.  Instead
+    it prints a short description of the trade and returns a mock transaction
+    signature.  The behaviour differs slightly based on whether the
+    application is running in ``test`` or ``live`` mode so that downstream
+    consumers can react accordingly.
+
     Parameters
     ----------
     config:
@@ -16,6 +22,12 @@ def execute_trade(config: AppConfig, opportunity: dict) -> str:
     Returns
     -------
     str
-        Transaction signature.
+        Transaction signature placeholder.
     """
-    raise NotImplementedError("Trade execution not implemented")
+
+    if config.is_live:
+        print(f"Executing trade in live mode: {opportunity}")
+        return "LIVE_TX_SIGNATURE"
+
+    print(f"Simulated trade: {opportunity}")
+    return "TEST_TX_SIGNATURE"

--- a/arbitrage/scanner.py
+++ b/arbitrage/scanner.py
@@ -6,7 +6,25 @@ from .config import AppConfig
 def scan_arbitrage(config: AppConfig):
     """Yield arbitrage opportunities.
 
-    This is a placeholder implementation. A real version would query
-    Jupiter's API and evaluate token routes for profit potential.
+    This stubbed implementation creates a fake opportunity when running in
+    ``test`` mode.  In a production system the scanner would query external
+    services such as Jupiter's API and evaluate the routes returned for
+    profit potential.
     """
-    raise NotImplementedError("Arbitrage scanning not implemented")
+
+    opportunity = {
+        "pair": "SOL/USDC",
+        "path": ["SOL", "USDC", "SOL"],
+        "expected_profit_usd": 1.0,
+    }
+
+    if config.mode == "test":
+        # In test mode always yield a single synthetic opportunity so the rest
+        # of the system has something to act upon.
+        yield opportunity
+    else:
+        # In live mode only yield the opportunity when the expected profit is
+        # above the configured minimum.  This keeps the example implementation
+        # simple while demonstrating how the configuration might be used.
+        if opportunity["expected_profit_usd"] >= config.min_profit_usd:
+            yield opportunity

--- a/arbitrage/wallet.py
+++ b/arbitrage/wallet.py
@@ -1,13 +1,21 @@
 """Wallet integration stubs."""
 
 class Wallet:
-    def __init__(self, keypair_path: str | None = None) -> None:
+    def __init__(self, keypair_path: str | None = None, initial_balance: float | None = None) -> None:
         self.keypair_path = keypair_path
-        # TODO: load keypair and connect to Solana
+        # In a real implementation we would load the keypair from the supplied
+        # path and establish a connection to a Solana RPC endpoint.  For this
+        # example we simply store a mock balance that can be queried by the
+        # application.  Allowing ``initial_balance`` to be specified makes the
+        # class a little easier to test or demonstrate without additional
+        # infrastructure.
+        self._balance = float(initial_balance) if initial_balance is not None else 100.0
 
     def get_balance(self) -> float:
         """Return wallet balance in SOL.
 
-        This is a stub that would normally query the Solana RPC.
+        The balance is a locally stored value and does not reflect real on-chain
+        data.  It exists purely to provide a usable API surface for components
+        that expect a wallet object.
         """
-        raise NotImplementedError("Wallet balance fetch not implemented")
+        return self._balance


### PR DESCRIPTION
## Summary
- implement stub logic for scanner, executor and wallet modules so they no longer raise `NotImplementedError`
- update README to note simplistic trading logic

## Testing
- `pytest -q`