### PR TITLE
Use JSON dataset for scanning opportunities

### DIFF
--- a/arbitrage/data/opportunities.json
+++ b/arbitrage/data/opportunities.json
@@ -1,0 +1,5 @@
+[
+  {"pair": "SOL/USDC", "path": ["SOL", "USDC", "SOL"], "expected_profit_usd": 0.8},
+  {"pair": "BTC/USDC", "path": ["BTC", "USDC", "BTC"], "expected_profit_usd": 1.2},
+  {"pair": "ETH/SOL", "path": ["ETH", "SOL", "ETH"], "expected_profit_usd": 0.5}
+]

--- a/arbitrage/scanner.py
+++ b/arbitrage/scanner.py
@@ -1,30 +1,39 @@
 """Arbitrage opportunity scanner stubs."""
 
+from pathlib import Path
+import json
+
 from .config import AppConfig
 
 
 def scan_arbitrage(config: AppConfig):
     """Yield arbitrage opportunities.
 
-    This stubbed implementation creates a fake opportunity when running in
-    ``test`` mode.  In a production system the scanner would query external
-    services such as Jupiter's API and evaluate the routes returned for
-    profit potential.
+    This implementation reads opportunities from a JSON file when running in
+    ``test`` mode.  The file provides a simple stand in for real market data
+    so the rest of the application can operate on realistic input without
+    requiring network access.  In a production system the scanner would query
+    external services such as Jupiter's API and evaluate the routes returned
+    for profit potential.
     """
 
-    opportunity = {
-        "pair": "SOL/USDC",
-        "path": ["SOL", "USDC", "SOL"],
-        "expected_profit_usd": 1.0,
-    }
-
     if config.mode == "test":
-        # In test mode always yield a single synthetic opportunity so the rest
-        # of the system has something to act upon.
-        yield opportunity
+        # Load opportunities from the bundled JSON dataset.  This simulates
+        # fetching real market data while keeping the code self contained.
+        data_path = Path(__file__).resolve().parent / "data" / "opportunities.json"
+        with data_path.open("r", encoding="utf-8") as f:
+            opportunities = json.load(f)
+
+        for item in opportunities:
+            yield item
     else:
-        # In live mode only yield the opportunity when the expected profit is
-        # above the configured minimum.  This keeps the example implementation
-        # simple while demonstrating how the configuration might be used.
+        # Fallback dummy opportunity for live mode. In a real implementation
+        # this branch would query external services.
+        opportunity = {
+            "pair": "SOL/USDC",
+            "path": ["SOL", "USDC", "SOL"],
+            "expected_profit_usd": 1.0,
+        }
+
         if opportunity["expected_profit_usd"] >= config.min_profit_usd:
             yield opportunity

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,14 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from arbitrage.config import AppConfig
+from arbitrage.scanner import scan_arbitrage
+
+
+def test_scanner_returns_data():
+    cfg = AppConfig(mode="test")
+    opportunities = list(scan_arbitrage(cfg))
+    assert len(opportunities) > 0
+    # Ensure the first opportunity has expected keys
+    assert "pair" in opportunities[0]
+    assert "expected_profit_usd" in opportunities[0]


### PR DESCRIPTION
## Summary
- load test opportunities from `arbitrage/data/opportunities.json`
- update scanner to read this dataset and yield results
- add unit test checking that test scanner returns data

## Testing
- `pytest -q`