### PR TITLE
Implement Jupiter API live data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,13 @@ Run the CLI in test mode:
 python app.py --mode test
 ```
 
+By default the application uses a bundled dummy dataset.  To fetch live market
+quotes via Jupiter's API in an environment that has Internet access, pass the
+``--data-source live`` option:
+
+```bash
+python app.py --mode test --data-source live
+```
+
 The command-line interface and module stubs can be extended to integrate the
 Jupiter aggregator API, Helius data sources, and real trade execution.

--- a/app.py
+++ b/app.py
@@ -9,11 +9,12 @@ from arbitrage.executor import execute_trade
 
 @click.command()
 @click.option("--mode", type=click.Choice(["test", "live"]), default="test", help="Run mode")
+@click.option("--data-source", type=click.Choice(["dummy", "live"]), default="dummy", help="Market data source")
 @click.option("--dashboard", is_flag=True, help="Launch dashboard")
-def main(mode: str, dashboard: bool) -> None:
+def main(mode: str, data_source: str, dashboard: bool) -> None:
     """Entry point for the CLI."""
-    config = AppConfig(mode=mode)
-    click.echo(f"Running in {config.mode} mode")
+    config = AppConfig(mode=mode, data_source=data_source)
+    click.echo(f"Running in {config.mode} mode using {config.data_source} data")
 
     if dashboard:
         click.echo("Dashboard not implemented")

--- a/arbitrage/config.py
+++ b/arbitrage/config.py
@@ -5,6 +5,7 @@ from typing import List
 class AppConfig:
     """Configuration for the trading app."""
     mode: str = "test"  # "test" or "live"
+    data_source: str = "dummy"  # "dummy" or "live"
     min_profit_usd: float = 0.5
     max_slippage_pct: float = 0.3
     trade_cooldown_sec: int = 15
@@ -13,3 +14,8 @@ class AppConfig:
     @property
     def is_live(self) -> bool:
         return self.mode == "live"
+
+    @property
+    def uses_live_data(self) -> bool:
+        """Return ``True`` if live market data should be fetched."""
+        return self.data_source == "live"

--- a/arbitrage/scanner.py
+++ b/arbitrage/scanner.py
@@ -3,6 +3,12 @@
 from pathlib import Path
 import json
 
+TOKEN_MINTS = {
+    "SOL": "So11111111111111111111111111111111111111112",
+    "USDC": "EPjFWdd5AufqSSqeM2qP2AMi9kNo6TwL8NXKDxNqGsQ",
+    "USDT": "Es9vMFrzaCERj2QTTbkfSUmB7So8yKhvKXgjx6BX3VWn",
+}
+
 from .config import AppConfig
 
 
@@ -17,23 +23,66 @@ def scan_arbitrage(config: AppConfig):
     for profit potential.
     """
 
-    if config.mode == "test":
-        # Load opportunities from the bundled JSON dataset.  This simulates
-        # fetching real market data while keeping the code self contained.
-        data_path = Path(__file__).resolve().parent / "data" / "opportunities.json"
-        with data_path.open("r", encoding="utf-8") as f:
-            opportunities = json.load(f)
+    if config.data_source == "dummy":
+        if config.mode == "test":
+            # Load opportunities from the bundled JSON dataset.  This simulates
+            # fetching real market data while keeping the code self contained.
+            data_path = Path(__file__).resolve().parent / "data" / "opportunities.json"
+            with data_path.open("r", encoding="utf-8") as f:
+                opportunities = json.load(f)
 
-        for item in opportunities:
-            yield item
-    else:
-        # Fallback dummy opportunity for live mode. In a real implementation
-        # this branch would query external services.
+            for item in opportunities:
+                yield item
+        else:
+            # Fallback dummy opportunity for live mode.
+            opportunity = {
+                "pair": "SOL/USDC",
+                "path": ["SOL", "USDC", "SOL"],
+                "expected_profit_usd": 1.0,
+            }
+
+            if opportunity["expected_profit_usd"] >= config.min_profit_usd:
+                yield opportunity
+    elif config.data_source == "live":
+        # Query Jupiter's public quote API for SOL -> USDC routes.  The
+        # response describes multiple swap routes.  For simplicity we pick the
+        # first one and convert the output amount to a profit metric.
+        #
+        # This code path requires network access.  It will raise an exception if
+        # the HTTP request fails or if the response structure does not match the
+        # expectations.  In offline environments the request will fail.
+        import json as _json
+        from urllib import parse, request
+
+        base_url = "https://quote-api.jup.ag/v6/quote"
+        params = {
+            "inputMint": TOKEN_MINTS["SOL"],
+            "outputMint": TOKEN_MINTS["USDC"],
+            # Quote for one SOL (9 decimals)
+            "amount": 1_000_000_000,
+            "slippageBps": int(config.max_slippage_pct * 100),
+        }
+
+        url = f"{base_url}?{parse.urlencode(params)}"
+        with request.urlopen(url, timeout=10) as resp:
+            data = _json.load(resp)
+
+        routes = data.get("data") or data.get("routes", [])
+        if not routes:
+            return
+
+        best_route = routes[0]
+        out_amount = int(best_route.get("outAmount", 0))
+        # USDC has 6 decimals
+        out_amount_usd = out_amount / 1_000_000
+
         opportunity = {
             "pair": "SOL/USDC",
             "path": ["SOL", "USDC", "SOL"],
-            "expected_profit_usd": 1.0,
+            "expected_profit_usd": out_amount_usd,
         }
 
         if opportunity["expected_profit_usd"] >= config.min_profit_usd:
             yield opportunity
+    else:
+        raise ValueError(f"Unknown data source: {config.data_source}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,3 +9,4 @@ def test_cli_help():
     result = subprocess.run([sys.executable, "app.py", "--help"], capture_output=True, text=True)
     assert result.returncode == 0
     assert "--mode" in result.stdout
+    assert "--data-source" in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,5 +4,7 @@ from arbitrage.config import AppConfig
 def test_default_config():
     cfg = AppConfig()
     assert cfg.mode == "test"
+    assert cfg.data_source == "dummy"
     assert cfg.is_live is False
+    assert cfg.uses_live_data is False
     assert "SOL" in cfg.watchlist_tokens

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -6,7 +6,7 @@ from arbitrage.scanner import scan_arbitrage
 
 
 def test_scanner_returns_data():
-    cfg = AppConfig(mode="test")
+    cfg = AppConfig(mode="live", data_source="live")
     opportunities = list(scan_arbitrage(cfg))
     assert len(opportunities) > 0
     # Ensure the first opportunity has expected keys


### PR DESCRIPTION
## Summary
- fetch SOL/USDC quotes from Jupiter when using `--data-source live`
- document Jupiter API usage in README
- update scanner test to require live data

## Testing
- `pytest -q` *(fails: urllib.error.URLError: <urlopen error timed out>)*